### PR TITLE
Fix wrong display of post-count and message text

### DIFF
--- a/background.js
+++ b/background.js
@@ -111,10 +111,10 @@ function checkNotifications(data) {
 
 function checkProfileStats(data) {
     chrome.storage.local.set({
-        'posts': $(data).find(".stats").text().split(":")[1].replace("\n", "")
+        'posts': $(data).find("#content").find(".stats").text().split(":")[1]
     });
     chrome.storage.local.set({
-        'rating': $(data).find(".dark_postrating_positive").text()
+        'rating': $(data).find("#content").find(".dark_postrating_positive").text()
     });
 }
 

--- a/background.js
+++ b/background.js
@@ -111,7 +111,7 @@ function checkNotifications(data) {
 
 function checkProfileStats(data) {
     chrome.storage.local.set({
-        'posts': $(data).find("#content").find(".stats").text().split(":")[1]
+        'posts': $(data).find("#content").find(".stats").text().split(":")[1].replace("\n", "")
     });
     chrome.storage.local.set({
         'rating': $(data).find("#content").find(".dark_postrating_positive").text()


### PR DESCRIPTION
Spigotmc.org seems to list the info twice now which results in some strange display error. (Double post count and "Messages" after the message count) This fixes that by only finding the parts inside of the div with the id "content".
